### PR TITLE
PAN-1721: allow passing multiple validator addresses to deploy script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN anvil --port 8545 --chain-id 31337 --state-interval 1 --dump-state anvil-sta
     while ! nc -z 127.0.0.1 8545; do echo 'Waiting for anvil to be available'; sleep 1; done && \
     forge script ./script/DeployContracts.s.sol --account local_deployer \
     --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 \
-    --sig "run(address,uint256,uint256,uint256)" 0x88CE2c1d82328f84Dd197f63482A3B68E18cD707 \
-    100000000000000000 100000000000000000 0 --broadcast && \
+    --sig "run(address,uint256,uint256,uint256,address[])" 0x88CE2c1d82328f84Dd197f63482A3B68E18cD707 \
+    100000000000000000 100000000000000000 0 [] --broadcast && \
     tee BNB_CHAIN.json AVALANCHE.json POLYGON.json \
     CRONOS.json FANTOM.json CELO.json < ETHEREUM.json && \
     echo "Anvil started, running deployment script..." && \

--- a/script/DeployContracts.s.sol
+++ b/script/DeployContracts.s.sol
@@ -23,8 +23,8 @@ import {BitpandaEcosystemTokenDeployer} from "./helpers/BitpandaEcosystemTokenDe
  * @dev Usage
  * forge script ./script/DeployContracts.s.sol --account <account> \
  *     --sender <sender> --rpc-url <rpc alias> --slow --force \
- *     --sig "run(address,uint256,uint256,uint256)" <validator> <panSupply> \
- *     <bestSupply> <nextTransferId>
+ *     --sig "run(address,uint256,uint256,uint256,address[])" <validator> <panSupply> \
+ *     <bestSupply> <nextTransferId> <otherValidators>
  */
 contract DeployContracts is
     PantosHubDeployer,
@@ -69,10 +69,11 @@ contract DeployContracts is
     }
 
     function run(
-        address validator,
+        address primaryValidator,
         uint256 panSupply,
         uint256 bestSupply,
-        uint256 nextTransferId
+        uint256 nextTransferId,
+        address[] memory otherValidators
     ) public {
         vm.startBroadcast();
 
@@ -88,13 +89,18 @@ contract DeployContracts is
             pantosHubProxy,
             pantosForwarder,
             pantosToken,
-            // PAN-1721: primary validator node address
-            validator
+            primaryValidator
         );
 
-        // PAN-1721: all validator node addresses
-        address[] memory validatorNodeAddresses = new address[](1);
-        validatorNodeAddresses[0] = validator;
+        // all validator node addresses
+        address[] memory validatorNodeAddresses = new address[](
+            otherValidators.length + 1
+        );
+        validatorNodeAddresses[0] = primaryValidator;
+        for (uint i; i < otherValidators.length; i++) {
+            validatorNodeAddresses[i + 1] = otherValidators[i];
+        }
+
         initializePantosForwarder(
             pantosForwarder,
             pantosHubProxy,

--- a/script/README.md
+++ b/script/README.md
@@ -59,8 +59,13 @@ Enter password: # (Hit enter for an empty password)
 
 ### DeployContracts
 
+With single validator
 ```bash
-$ forge script ./script/DeployContracts.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "run(address,uint256,uint256,uint256)" 0x88CE2c1d82328f84Dd197f63482A3B68E18cD707 100000000000000000 100000000000000000 0
+$ forge script ./script/DeployContracts.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "run(address,uint256,uint256,uint256,address[])" 0x88CE2c1d82328f84Dd197f63482A3B68E18cD707 100000000000000000 100000000000000000 0 []
+```
+With multiple validators
+```
+$ forge script ./script/DeployContracts.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "run(address,uint256,uint256,uint256,address[])" 0x88CE2c1d82328f84Dd197f63482A3B68E18cD707 100000000000000000 100000000000000000 0 [0xAa1ea8611639537A89Cb5925903Fd1fb28027DE9,0xBB2166dC315dC02F314597eCf867C3dfB45ED205,0xCC0DF974953820B649Bb67F167f01cd265Ea5B0A]
 ```
 
 ### RegisterExternalTokens


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Updated `DeployContracts.s.sol` to accept the address of the primary validator node and 
an arbitrary number of additional validator node addresses.

## Related Tickets & Documents
PAN-1721
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## QA Instructions
Test `DeployContracts.s.sol` script to deploy all the contracts using multiple validators.
