### PR TITLE
fix: use another directory to mount a second volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,10 @@ services:
     environment:
       CHAIN_ID: 31337
     volumes:
+      # Workaround so that we can also access the data locally
+      # Without needing an additional container
       - eth-data:/data
-      - ./data/eth:/data
+      - ./data/eth:/data-static
     ports:
       - 8545:8545
     healthcheck:
@@ -49,8 +51,10 @@ services:
     networks:
       pantos-ethereum:
     volumes:
+      # Workaround so that we can also access the data locally
+      # Without needing an additional container
       - bnb-data:/data
-      - ./data/bnb:/data
+      - ./data/bnb:/data-static
     environment:
       CHAIN_ID: 31338
     ports:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Apparently docker doesn't allow us to mount the same directory on two different volumes. It does fail quietly and continue the mount without creating the first volume. This workarounds that issue.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #PAN-1832
- Closes #

## QA Instructions

_Please replace this line with instructions on how to test your changes._


## [optional] Are there any post deployment tasks we need to perform?