### PR TITLE
feat: remove --sender flag from forge script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,11 @@ RUN anvil --port 8545 --chain-id 31337 --state-interval 1 --dump-state anvil-sta
     while ! nc -z 127.0.0.1 8545; do echo 'Waiting for anvil to be available'; sleep 1; done && \
     echo '{"deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","medium_critical_ops":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","pauser": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","super_critical_ops": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"}' > ETHEREUM-ROLES.json && \
     forge script ./script/DeployContracts.s.sol --account local_deployer \
-    --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 \
-    --sig "deploy(uint256,uint256)" 100000000000000000 100000000000000000 --broadcast && \
+    --password '' --rpc-url local-8545 --sig "deploy(uint256,uint256)" \
+    100000000000000000 100000000000000000 --broadcast && \
     forge script ./script/DeployContracts.s.sol --account local_deployer --password '' \
-    --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 --sig \
-    "roleActions(uint256,address,address[],bool)" 0 0x88CE2c1d82328f84Dd197f63482A3B68E18cD707 \
-    [] false --broadcast && \
+    --rpc-url local-8545 --sig "roleActions(uint256,address,address[],bool)" \
+    0 0x88CE2c1d82328f84Dd197f63482A3B68E18cD707 [] false --broadcast && \
     # Convert the Ethereum json to an env file and copy it over
     for chain in ETHEREUM BNB_CHAIN AVALANCHE POLYGON CRONOS FANTOM CELO; do \
     file="$chain.json"; \
@@ -49,8 +48,7 @@ RUN anvil --port 8545 --chain-id 31337 --state-interval 1 --dump-state anvil-sta
     # Fetch the hash of the file here
     HASH=$(sha256sum anvil-state.json | cut -d ' ' -f 1) && \
     forge script ./script/RegisterExternalTokens.s.sol --account local_deployer \
-    --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
-    --rpc-url local-8545 --sig "roleActions(bool)" false --broadcast && \
+    --password '' --rpc-url local-8545  --sig "roleActions(bool)" false --broadcast && \
     echo "Waiting for the state to change..." && \
     # While the state is the same, keep waiting
     while [ $(sha256sum anvil-state.json | cut -d ' ' -f 1) = $HASH ]; do sleep 1; done

--- a/script/README.md
+++ b/script/README.md
@@ -60,7 +60,7 @@ Enter password: # (Hit enter for an empty password)
 ### DeploySafe
 
 ```bash
-$ forge script ./script/DeploySafe.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "deploySafes(address[],uint256,address[],uint256,address[],uint256,address[],uint256)" [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266] 1 [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266] 1 [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266] 1 [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266] 1
+$ forge script ./script/DeploySafe.s.sol --account local_deployer --password '' --rpc-url local-8545 -vvvv --sig "deploySafes(address[],uint256,address[],uint256,address[],uint256,address[],uint256)" [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266] 1 [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266] 1 [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266] 1 [0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266] 1
 ```
 
 ### DeployContracts
@@ -68,7 +68,7 @@ $ forge script ./script/DeploySafe.s.sol --account local_deployer --password '' 
 Deploy all contracts from any gas paying account
 
 ```bash
-$ forge script ./script/DeployContracts.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "deploy(uint256,uint256)" 100000000000000000 100000000000000000
+$ forge script ./script/DeployContracts.s.sol --account local_deployer --password '' --rpc-url local-8545 -vvvv --sig "deploy(uint256,uint256)" 100000000000000000 100000000000000000
 ```
 
 RoleActions for all deployed contracts (simulation only!)
@@ -88,7 +88,7 @@ $ forge script ./script/DeployContracts.s.sol --rpc-url local-8545 -vvvv --sig "
 ### SubmitSafeTxs
 
 ```bash
-$ forge script ./script/SubmitSafeTxs.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545  -vvvv --sig "run()"
+$ forge script ./script/SubmitSafeTxs.s.sol --account local_deployer --password '' --rpc-url local-8545  -vvvv --sig "run()"
 ```
 
 ### RegisterExternalTokens
@@ -108,7 +108,7 @@ $ forge script ./script/UpdateFeeFactors.s.sol --rpc-url local-8545 -vvvv --sig 
 Deploy all contracts from any gas paying account
 
 ```bash
-$ forge script ./script/redeploy/RedeployHub.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "deploy(address)" 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+$ forge script ./script/redeploy/RedeployHub.s.sol --account local_deployer --password '' --rpc-url local-8545 -vvvv --sig "deploy(address)" 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
 
 ```
 
@@ -124,7 +124,7 @@ forge script ./script/redeploy/RedeployHub.s.sol --rpc-url local-8545 -vvvv --si
 Deploy all facet contracts from any gas paying account
 
 ```bash
-$ forge script ./script/redeploy/UpgradeHub.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "deploy()"
+$ forge script ./script/redeploy/UpgradeHub.s.sol --account local_deployer --password '' --rpc-url local-8545 -vvvv --sig "deploy()"
 ```
 
 RoleActions for all redeployed contracts (simulation only!)
@@ -137,7 +137,7 @@ forge script ./script/redeploy/UpgradeHub.s.sol --rpc-url local-8545 -vvvv --sig
 Deploy new contracts from any gas paying account
 
 ```bash
-forge script ./script/redeploy/RedeployForwarder.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "deploy(address)" 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+forge script ./script/redeploy/RedeployForwarder.s.sol --account local_deployer --password '' --rpc-url local-8545 -vvvv --sig "deploy(address)" 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
 ```
 RoleActions for all redeployed contracts (simulation only!)
 ```bash
@@ -149,7 +149,7 @@ forge script ./script/redeploy/RedeployForwarder.s.sol --rpc-url local-8545 -vvv
 Deploy new contracts from any gas paying account
 
 ```bash
-$ forge script ./script/redeploy/RedeployHubAndForwarder.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "deploy(address)" 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+$ forge script ./script/redeploy/RedeployHubAndForwarder.s.sol --account local_deployer --password '' --rpc-url local-8545 -vvvv --sig "deploy(address)" 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
 ```
 RoleActions for all redeployed contracts (simulation only!)
 ```bash
@@ -159,7 +159,7 @@ forge script ./script/redeploy/RedeployHubAndForwarder.s.sol --rpc-url local-854
 ### UpgradeHubAndRedeployForwarder
 
 ```bash
-forge script ./script/redeploy/UpgradeHubAndRedeployForwarder.s.sol --account local_deployer --password '' --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url local-8545 -vvvv --sig "deploy(address)" 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+forge script ./script/redeploy/UpgradeHubAndRedeployForwarder.s.sol --account local_deployer --password '' --rpc-url local-8545 -vvvv --sig "deploy(address)" 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
 ```
 
 RoleActions for all redeployed contracts (simulation only!)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Forge was unable to infer the sender from the --account flag due to some legacy code. However, they addressed the issue in the following PR: https://github.com/foundry-rs/foundry/pull/7141/files. We are now removing the flag everywhere, since it's not needed anymore.