### PR TITLE
feat: remove address parameters from update scripts

### DIFF
--- a/script/README.md
+++ b/script/README.md
@@ -129,49 +129,49 @@ $ forge script ./script/RegisterExternalTokens.s.sol --rpc-url local-8545 -vvvv 
 ### UpdateFeeFactors
 
 ```bash
-$ forge script ./script/update/parameters/UpdateFeeFactors.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(address,address)" 0x0165878A594ca255338adfa4d48449f69242Eb8F 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
+$ forge script ./script/update/parameters/UpdateFeeFactors.s.sol --rpc-url local-8545 -vvvv --sig "roleActions()"
 ```
 
 ### UpdateMinimumDeposit
 
 ```bash
-$ forge script ./script/update/parameters/UpdateMinimumDeposit.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(uint256,address,address)" 1 0x0165878A594ca255338adfa4d48449f69242Eb8F 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
+$ forge script ./script/update/parameters/UpdateMinimumDeposit.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(uint256)" 1
 ```
 
 ### UpdateParameterUpdateDelay
 
 ```bash
-$ forge script ./script/update/parameters/UpdateParameterUpdateDelay.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(uint256,address,address)" 1 0x0165878A594ca255338adfa4d48449f69242Eb8F 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
+$ forge script ./script/update/parameters/UpdateParameterUpdateDelay.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(uint256)" 1
 ```
 
 ### UpdateUnbondingPeriod
 
 ```bash
-$ forge script ./script/update/parameters/UpdateUnbondingPeriod.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(uint256,address,address)" 1 0x0165878A594ca255338adfa4d48449f69242Eb8F 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
+$ forge script ./script/update/parameters/UpdateUnbondingPeriod.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(uint256)" 1
 ```
 
 ### AddValidatorNode
 
 ```bash
-$ forge script ./script/update/validators/AddValidatorNode.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(address,address,address)" 0x9E7c67F9DE01a9ff5547f172a7d1119E62214667 0x0165878A594ca255338adfa4d48449f69242Eb8F 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
+$ forge script ./script/update/validators/AddValidatorNode.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(address)" 0x9E7c67F9DE01a9ff5547f172a7d1119E62214667
 ```
 
 ### RemoveValidatorNode
 
 ```bash
-$ forge script ./script/update/parameters/RemoveValidatorNode.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(address,address,address)" 0x9E7c67F9DE01a9ff5547f172a7d1119E62214667 0x0165878A594ca255338adfa4d48449f69242Eb8F 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
+$ forge script ./script/update/parameters/RemoveValidatorNode.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(address)" 0x9E7c67F9DE01a9ff5547f172a7d1119E62214667
 ```
 
 ### SetMinValidatorNodeSignatures
 
 ```bash
-$ forge script ./script/update/validators/SetMinValidatorNodeSignatures.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(uint256,address,address)" 5 0x0165878A594ca255338adfa4d48449f69242Eb8F 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
+$ forge script ./script/update/validators/SetMinValidatorNodeSignatures.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(uint256)" 5
 ```
 
 ### SetPrimaryValidatorNode
 
 ```bash
-$ forge script ./script/update/validators/SetPrimaryValidatorNode.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(address,address,address)" 0x9E7c67F9DE01a9ff5547f172a7d1119E62214667 0x0165878A594ca255338adfa4d48449f69242Eb8F 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6
+$ forge script ./script/update/validators/SetPrimaryValidatorNode.s.sol --rpc-url local-8545 -vvvv --sig "roleActions(address)" 0x9E7c67F9DE01a9ff5547f172a7d1119E62214667
 ```
 
 ### AddOwnerWithThreshold

--- a/script/update/parameters/UpdateFeeFactors.s.sol
+++ b/script/update/parameters/UpdateFeeFactors.s.sol
@@ -8,7 +8,7 @@ import {IPantosHub} from "../../../src/interfaces/IPantosHub.sol";
 import {PantosTypes} from "../../../src/interfaces/PantosTypes.sol";
 import {AccessController} from "../../../src/access/AccessController.sol";
 
-import {PantosBaseScript} from "../../helpers/PantosHubDeployer.s.sol";
+import {PantosBaseAddresses} from "./../../helpers/PantosBaseAddresses.s.sol";
 import {SafeAddresses} from "../../helpers/SafeAddresses.s.sol";
 import {UpdateBase} from "./UpdateBase.s.sol";
 
@@ -19,17 +19,16 @@ import {UpdateBase} from "./UpdateBase.s.sol";
  *
  * @dev Usage
  * forge script ./script/update/parameters/UpdateFeeFactors.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(address,address)" <accessControllerAddress> \
- *      <pantosHubProxy>
+ *      --sig "roleActions()"
  */
-contract UpdateFeeFactors is PantosBaseScript, SafeAddresses, UpdateBase {
-    function roleActions(
-        address accessControllerAddress,
-        address pantosHubProxyAddress
-    ) public {
-        IPantosHub pantosHubProxy = IPantosHub(pantosHubProxyAddress);
+contract UpdateFeeFactors is PantosBaseAddresses, SafeAddresses, UpdateBase {
+    function roleActions() public {
+        readContractAddresses(determineBlockchain());
+        IPantosHub pantosHubProxy = IPantosHub(
+            getContractAddress(Contract.HUB_PROXY, false)
+        );
         AccessController accessController = AccessController(
-            accessControllerAddress
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
         );
         vm.startBroadcast(accessController.mediumCriticalOps());
 

--- a/script/update/parameters/UpdateMinimumDeposit.s.sol
+++ b/script/update/parameters/UpdateMinimumDeposit.s.sol
@@ -8,7 +8,7 @@ import {IPantosHub} from "../../../src/interfaces/IPantosHub.sol";
 import {PantosTypes} from "../../../src/interfaces/PantosTypes.sol";
 import {AccessController} from "../../../src/access/AccessController.sol";
 
-import {PantosBaseScript} from "../../helpers/PantosHubDeployer.s.sol";
+import {PantosBaseAddresses} from "./../../helpers/PantosBaseAddresses.s.sol";
 import {SafeAddresses} from "../../helpers/SafeAddresses.s.sol";
 import {UpdateBase} from "./UpdateBase.s.sol";
 
@@ -19,18 +19,20 @@ import {UpdateBase} from "./UpdateBase.s.sol";
  *
  * @dev Usage
  * forge script ./script/update/parameters/UpdateMinimumDeposit.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(uint256, address,address)" <newMinimumDeposit> \
- *      <accessControllerAddress> <pantosHubProxy>
+ *      --sig "roleActions(uint256)" <newMinimumDeposit>
  */
-contract UpdateMinimumDeposit is PantosBaseScript, SafeAddresses, UpdateBase {
-    function roleActions(
-        uint256 newMinimumDeposit,
-        address accessControllerAddress,
-        address pantosHubProxyAddress
-    ) public {
-        IPantosHub pantosHubProxy = IPantosHub(pantosHubProxyAddress);
+contract UpdateMinimumDeposit is
+    PantosBaseAddresses,
+    SafeAddresses,
+    UpdateBase
+{
+    function roleActions(uint256 newMinimumDeposit) public {
+        readContractAddresses(determineBlockchain());
+        IPantosHub pantosHubProxy = IPantosHub(
+            getContractAddress(Contract.HUB_PROXY, false)
+        );
         AccessController accessController = AccessController(
-            accessControllerAddress
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
         );
         vm.startBroadcast(accessController.mediumCriticalOps());
         PantosTypes.UpdatableUint256

--- a/script/update/parameters/UpdateParameterUpdateDelay.s.sol
+++ b/script/update/parameters/UpdateParameterUpdateDelay.s.sol
@@ -8,7 +8,7 @@ import {IPantosHub} from "../../../src/interfaces/IPantosHub.sol";
 import {PantosTypes} from "../../../src/interfaces/PantosTypes.sol";
 import {AccessController} from "../../../src/access/AccessController.sol";
 
-import {PantosBaseScript} from "../../helpers/PantosHubDeployer.s.sol";
+import {PantosBaseAddresses} from "./../../helpers/PantosBaseAddresses.s.sol";
 import {SafeAddresses} from "../../helpers/SafeAddresses.s.sol";
 import {UpdateBase} from "./UpdateBase.s.sol";
 
@@ -19,22 +19,20 @@ import {UpdateBase} from "./UpdateBase.s.sol";
  *
  * @dev Usage
  * forge script ./script/update/parameters/UpdateParameterUpdateDelay.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(uint256,address,address)" <newParameterUpdateDelay> \
- *      <accessControllerAddress> <pantosHubProxy>
+ *      --sig "roleActions(uint256)" <newParameterUpdateDelay>
  */
 contract UpdateParameterUpdateDelay is
-    PantosBaseScript,
+    PantosBaseAddresses,
     SafeAddresses,
     UpdateBase
 {
-    function roleActions(
-        uint256 newParameterUpdateDelay,
-        address accessControllerAddress,
-        address pantosHubProxyAddress
-    ) public {
-        IPantosHub pantosHubProxy = IPantosHub(pantosHubProxyAddress);
+    function roleActions(uint256 newParameterUpdateDelay) public {
+        readContractAddresses(determineBlockchain());
+        IPantosHub pantosHubProxy = IPantosHub(
+            getContractAddress(Contract.HUB_PROXY, false)
+        );
         AccessController accessController = AccessController(
-            accessControllerAddress
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
         );
         vm.startBroadcast(accessController.mediumCriticalOps());
 

--- a/script/update/parameters/UpdateUnbondingPeriod.s.sol
+++ b/script/update/parameters/UpdateUnbondingPeriod.s.sol
@@ -8,7 +8,7 @@ import {IPantosHub} from "../../../src/interfaces/IPantosHub.sol";
 import {PantosTypes} from "../../../src/interfaces/PantosTypes.sol";
 import {AccessController} from "../../../src/access/AccessController.sol";
 
-import {PantosBaseScript} from "../../helpers/PantosHubDeployer.s.sol";
+import {PantosBaseAddresses} from "./../../helpers/PantosBaseAddresses.s.sol";
 import {SafeAddresses} from "../../helpers/SafeAddresses.s.sol";
 import {UpdateBase} from "./UpdateBase.s.sol";
 
@@ -20,18 +20,20 @@ import {UpdateBase} from "./UpdateBase.s.sol";
  *
  * @dev Usage
  * forge script ./script/update/parameters/UpdateUnbondingPeriod.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(uint256,address,address)" <newUnbondingPeriod> \
- *      <accessControllerAddress> <pantosHubProxy>
+ *      --sig "roleActions(uint256)" <newUnbondingPeriod>
  */
-contract UpdateUnbondingPeriod is PantosBaseScript, SafeAddresses, UpdateBase {
-    function roleActions(
-        uint256 newUnbondingPeriod,
-        address accessControllerAddress,
-        address pantosHubProxyAddress
-    ) public {
-        IPantosHub pantosHubProxy = IPantosHub(pantosHubProxyAddress);
+contract UpdateUnbondingPeriod is
+    PantosBaseAddresses,
+    SafeAddresses,
+    UpdateBase
+{
+    function roleActions(uint256 newUnbondingPeriod) public {
+        readContractAddresses(determineBlockchain());
+        IPantosHub pantosHubProxy = IPantosHub(
+            getContractAddress(Contract.HUB_PROXY, false)
+        );
         AccessController accessController = AccessController(
-            accessControllerAddress
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
         );
         vm.startBroadcast(accessController.mediumCriticalOps());
 

--- a/script/update/validators/AddValidatorNode.s.sol
+++ b/script/update/validators/AddValidatorNode.s.sol
@@ -18,24 +18,23 @@ import {SafeAddresses} from "./../../helpers/SafeAddresses.s.sol";
  * @dev Usage
  * 1. Add a new validator node
  * forge script ./script/update/validators/AddValidatorNode.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(address,address,address)" <newValidatorNode> \
- *      <accessControllerAddress>  <pantosForwarder>
+ *      --sig "roleActions(address)" <newValidatorNode>
  * 2. Add a new validator node and change the minimum threshold of validator nodes.
  * forge script ./script/update/validators/AddValidatorNode.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(address,address,address)" <newValidatorNode> \
- *      <newMinimumThreshold> <accessControllerAddress>  <pantosForwarder>
+ *      --sig "roleActions(address,uint256)" <newValidatorNode> <newMinimumThreshold>
  */
 contract AddValidatorNode is PantosBaseAddresses, SafeAddresses {
     AccessController accessController;
     PantosForwarder public pantosForwarder;
 
-    function roleActions(
-        address newValidatorNode,
-        address accessController_,
-        address pantosForwarder_
-    ) public {
-        accessController = AccessController(accessController_);
-        pantosForwarder = PantosForwarder(pantosForwarder_);
+    function roleActions(address newValidatorNode) public {
+        readContractAddresses(determineBlockchain());
+        accessController = AccessController(
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
+        );
+        pantosForwarder = PantosForwarder(
+            getContractAddress(Contract.FORWARDER, false)
+        );
 
         address[] memory validatorNodes = pantosForwarder.getValidatorNodes();
         for (uint256 i = 0; i < validatorNodes.length; i++) {
@@ -60,12 +59,15 @@ contract AddValidatorNode is PantosBaseAddresses, SafeAddresses {
 
     function roleActions(
         address newValidatorNode,
-        uint256 newMinimumThreshold,
-        address accessController_,
-        address pantosForwarder_
+        uint256 newMinimumThreshold
     ) public {
-        accessController = AccessController(accessController_);
-        pantosForwarder = PantosForwarder(pantosForwarder_);
+        readContractAddresses(determineBlockchain());
+        accessController = AccessController(
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
+        );
+        pantosForwarder = PantosForwarder(
+            getContractAddress(Contract.FORWARDER, false)
+        );
 
         require(
             newMinimumThreshold > 0,

--- a/script/update/validators/RemoveValidatorNode.s.sol
+++ b/script/update/validators/RemoveValidatorNode.s.sol
@@ -18,25 +18,23 @@ import {SafeAddresses} from "./../../helpers/SafeAddresses.s.sol";
  * @dev Usage
  * 1. Remove a validator node.
  * forge script ./script/update/validators/RemoveValidatorNode.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(address,address,address)" <validatorNode> \
- *      <accessControllerAddress>  <pantosForwarder>
+ *      --sig "roleActions(address)" <validatorNode>
  * 2. Remove a validator node and change the minimum threshold of validator nodes.
  * forge script ./script/update/validators/RemoveValidatorNode.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(address,address,address)" <validatorNode> \
- *      <newMinimumThreshold> <accessControllerAddress>  <pantosForwarder>
+ *      --sig "roleActions(address,uint256)" <validatorNode> <newMinimumThreshold>
  */
 contract RemoveValidatorNode is PantosBaseAddresses, SafeAddresses {
     AccessController accessController;
     PantosForwarder public pantosForwarder;
 
-    function roleActions(
-        address validatorNode,
-        address accessController_,
-        address pantosForwarder_
-    ) public {
-        accessController = AccessController(accessController_);
-        pantosForwarder = PantosForwarder(pantosForwarder_);
-        console.log("pantos forwarder address: %s", pantosForwarder_);
+    function roleActions(address validatorNode) public {
+        readContractAddresses(determineBlockchain());
+        accessController = AccessController(
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
+        );
+        pantosForwarder = PantosForwarder(
+            getContractAddress(Contract.FORWARDER, false)
+        );
 
         address[] memory validatorNodes = pantosForwarder.getValidatorNodes();
         bool found = false;
@@ -66,12 +64,15 @@ contract RemoveValidatorNode is PantosBaseAddresses, SafeAddresses {
 
     function roleActions(
         address validatorNode,
-        uint256 newMinimumThreshold,
-        address accessController_,
-        address pantosForwarder_
+        uint256 newMinimumThreshold
     ) public {
-        accessController = AccessController(accessController_);
-        pantosForwarder = PantosForwarder(pantosForwarder_);
+        readContractAddresses(determineBlockchain());
+        accessController = AccessController(
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
+        );
+        pantosForwarder = PantosForwarder(
+            getContractAddress(Contract.FORWARDER, false)
+        );
 
         require(
             newMinimumThreshold > 0,

--- a/script/update/validators/SetMinValidatorNodeSignatures.s.sol
+++ b/script/update/validators/SetMinValidatorNodeSignatures.s.sol
@@ -17,20 +17,20 @@ import {SafeAddresses} from "./../../helpers/SafeAddresses.s.sol";
  *
  * @dev Usage
  * forge script ./script/update/parameters/SetMinValidatorNodeSignatures.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(address,address,uint256)" <newMinimumThreshold> \
- *      <accessControllerAddress> <pantosForwarder>
+ *      --sig "roleActions(uint256)" <newMinimumThreshold>
  */
 contract SetMinValidatorNodeSignatures is PantosBaseAddresses, SafeAddresses {
     AccessController accessController;
     PantosForwarder public pantosForwarder;
 
-    function roleActions(
-        uint256 newMinimumThreshold,
-        address accessController_,
-        address pantosForwarder_
-    ) public {
-        accessController = AccessController(accessController_);
-        pantosForwarder = PantosForwarder(pantosForwarder_);
+    function roleActions(uint256 newMinimumThreshold) public {
+        readContractAddresses(determineBlockchain());
+        accessController = AccessController(
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
+        );
+        pantosForwarder = PantosForwarder(
+            getContractAddress(Contract.FORWARDER, false)
+        );
 
         require(
             newMinimumThreshold > 0,

--- a/script/update/validators/SetPrimaryValidatorNode.s.sol
+++ b/script/update/validators/SetPrimaryValidatorNode.s.sol
@@ -17,20 +17,18 @@ import {SafeAddresses} from "./../../helpers/SafeAddresses.s.sol";
  *
  * @dev Usage
  * forge script ./script/update/parameters/SetPrimaryValidatorNode.s.sol --rpc-url <rpc alias>
- *      --sig "roleActions(address,address,address)" <newPirmaryValidatorNode> \
- *      <accessControllerAddress> <pantosHubProxy>
+ *      --sig "roleActions(address)" <newPirmaryValidatorNode>
  */
 contract SetPrimaryValidatorNode is PantosBaseAddresses, SafeAddresses {
     AccessController accessController;
     IPantosHub public pantosHub;
 
-    function roleActions(
-        address newPirmaryValidatorNode,
-        address accessController_,
-        address pantosHub_
-    ) public {
-        accessController = AccessController(accessController_);
-        pantosHub = IPantosHub(pantosHub_);
+    function roleActions(address newPirmaryValidatorNode) public {
+        readContractAddresses(determineBlockchain());
+        accessController = AccessController(
+            getContractAddress(Contract.ACCESS_CONTROLLER, false)
+        );
+        pantosHub = IPantosHub(getContractAddress(Contract.HUB_PROXY, false));
 
         address oldPrimaryValidatorNode = pantosHub.getPrimaryValidatorNode();
         if (oldPrimaryValidatorNode == newPirmaryValidatorNode) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The address of the known contracts (access controller, hub, forwarder) can be taken directly from the JSON files which hold the script addresses instead of the CLI parameters.