### PR TITLE
[PAN-2030] Protocol version and compact ABIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,14 @@ snapshot:
 abis: build
 	@set -e; \
 	mkdir -p "${ABI_PATH}"; \
+	jq '.abi' "${HUB_JSON_PATH}" > "${HUB_ABI_PATH}"; \
+	jq '.abi' "${FORWARDER_JSON_PATH}" > "${FORWARDER_ABI_PATH}"; \
+	jq '.abi' "${TOKEN_JSON_PATH}" > "${TOKEN_ABI_PATH}"
+
+.PHONY: abis-compact
+abis-compact: build
+	@set -e; \
+	mkdir -p "${ABI_PATH}"; \
 	jq -c '.abi' "${HUB_JSON_PATH}" > "${HUB_ABI_PATH}"; \
 	jq -c '.abi' "${FORWARDER_JSON_PATH}" > "${FORWARDER_ABI_PATH}"; \
 	jq -c '.abi' "${TOKEN_JSON_PATH}" > "${TOKEN_ABI_PATH}"

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,9 @@ snapshot:
 abis: build
 	@set -e; \
 	mkdir -p "${ABI_PATH}"; \
-	jq '.abi' "${HUB_JSON_PATH}" > "${HUB_ABI_PATH}"; \
-	jq '.abi' "${FORWARDER_JSON_PATH}" > "${FORWARDER_ABI_PATH}"; \
-	jq '.abi' "${TOKEN_JSON_PATH}" > "${TOKEN_ABI_PATH}"
+	jq -c '.abi' "${HUB_JSON_PATH}" > "${HUB_ABI_PATH}"; \
+	jq -c '.abi' "${FORWARDER_JSON_PATH}" > "${FORWARDER_ABI_PATH}"; \
+	jq -c '.abi' "${TOKEN_JSON_PATH}" > "${TOKEN_ABI_PATH}"
 
 .PHONY: docs
 docs:

--- a/script/helpers/Constants.s.sol
+++ b/script/helpers/Constants.s.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.26;
 
 library Constants {
     uint8 public constant MAJOR_PROTOCOL_VERSION = 0;
-    uint8 public constant MINOR_PROTOCOL_VERSION = 1;
+    uint8 public constant MINOR_PROTOCOL_VERSION = 2;
     uint8 public constant PATCH_PROTOCOL_VERSION = 0;
 
     uint256 public constant SERVICE_NODE_DEPOSIT_UNBONDING_PERIOD = 604800;

--- a/test/PantosBaseTest.t.sol
+++ b/test/PantosBaseTest.t.sol
@@ -14,7 +14,7 @@ import {AccessController} from "../src/access/AccessController.sol";
 
 abstract contract PantosBaseTest is Test {
     uint8 public constant MAJOR_PROTOCOL_VERSION = 0;
-    uint8 public constant MINOR_PROTOCOL_VERSION = 1;
+    uint8 public constant MINOR_PROTOCOL_VERSION = 2;
     uint8 public constant PATCH_PROTOCOL_VERSION = 0;
     bytes32 public immutable PROTOCOL_VERSION =
         bytes32(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The protocol version has been updated to 0.2.0 due to the recently added events and methods of the Pantos Hub interface. Apart from that, a new make target for creating compact contract ABIs has been added.